### PR TITLE
remove unused extension file

### DIFF
--- a/dynamodb-local.gemspec
+++ b/dynamodb-local.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Wraps installation and usage of the AWS DynamoDB local server tool}
   spec.homepage      = "https://github.com/jhuckabee/dynamodb-local"
   spec.license       = "MIT"
-  spec.extensions    = ["Rakefile"]
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Hi, thanks for the gem :smile: 

It appears that the Rakefile doesn't actually do anything during the install of the gem so there isn't a reason to have the spec.extensions call. I've only ever seen this used for extconf.rb, but I could be wrong.

In fact it cause an error for us when we try to install this gem in some cases. A normal `bundle install` to the system/users gems works fine, but at as soon as we try to do a `bundle install --path vendor/bundle` will fail with this error

```
    /Users/coreypurcell/.rubies/ruby-2.1.5/bin/ruby -rubygems /Users/coreypurcell/code/reactor_api/vendor/bundle/ruby/2.1.0/gems/rake-10.4.2/bin/rake RUBYARCHDIR=/Users/coreypurcell/code/reactor_api/vendor/bundle/ruby/2.1.0/bundler/gems/extensions/x86_64-darwin-14/2.1.0-static/dynamodb-local-9b7bba5c30a5 RUBYLIBDIR=/Users/coreypurcell/code/reactor_api/vendor/bundle/ruby/2.1.0/bundler/gems/extensions/x86_64-darwin-14/2.1.0-static/dynamodb-local-9b7bba5c30a5
rake aborted!
LoadError: cannot load such file -- bundler/gem_tasks
/Users/coreypurcell/code/reactor_api/vendor/bundle/ruby/2.1.0/bundler/gems/dynamodb-local-9b7bba5c30a5/Rakefile:1:in `<top (required)>'
(See full trace by running task with --trace)
```

As you can see it can't load bundler during the install, I can't figure out why this works when not using --path but it does. Thanks.
