### PR TITLE
ruby 3 compatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :prepare do
     mkdir_p ext_dir
     $stderr.print "Downloading DynamoDB local..."
     File.open(local_path, 'w') do |f|
-      f.write(open(dynamodb_local_url).read)
+      f.write(URI.open(dynamodb_local_url).read)
     end
     `tar -xzf #{local_path} -C #{ext_dir}`
     rm local_path

--- a/dynamodb-local.gemspec
+++ b/dynamodb-local.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_dependency "rake"
+  spec.add_dependency "open-uri"
 
 end


### PR DESCRIPTION
For ruby 3 per https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/ open-uri is now a gem - this adds it as a dependency and makes the Rakefile use it.

Also getting installation issues when rake is not install so have put this as a dependency
```
Installing dynamodb-local 0.0.6 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/jenkins/bundle/ruby/2.7.0/gems/dynamodb-local-0.0.6
rake
RUBYARCHDIR\=/home/jenkins/bundle/ruby/2.7.0/extensions/x86_64-linux/2.7.0/dynamodb-local-0.0.6
RUBYLIBDIR\=/home/jenkins/bundle/ruby/2.7.0/extensions/x86_64-linux/2.7.0/dynamodb-local-0.0.6
rake failedNo such file or directory - rake

Gem files will remain installed in
/home/jenkins/bundle/ruby/2.7.0/gems/dynamodb-local-0.0.6 for inspection.
Results logged to
/home/jenkins/bundle/ruby/2.7.0/extensions/x86_64-linux/2.7.0/dynamodb-local-0.0.6/gem_make.out

An error occurred while installing dynamodb-local (0.0.6), and Bundler cannot
continue.
Make sure that `gem install dynamodb-local -v '0.0.6' --source
'https://rubygems.org/'` succeeds before bundling.
```